### PR TITLE
Use rules_swift

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,1 @@
-build --xcode_version=14.1.0.14B47b
+build --xcode_version=14.0.1.14A400

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,1 @@
-build --xcode_version=14.0.1.14A400
+build --xcode_version=14.1.0.14B47b

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,15 +2,18 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_jar")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 http_archive(
+    name = "build_bazel_rules_swift",
+    sha256 = "c244e9f804a48c27fe490150c762d8b0c868b23ef93dc4e3f93d8117ca216d92",
+    url = "https://github.com/bazelbuild/rules_swift/releases/download/1.4.0/rules_swift.1.4.0.tar.gz",
+)
+
+
+http_archive(
     name = "com_github_buildbuddy_io_rules_xcodeproj",
     sha256 = "b4e71c7740bb8cfa4bc0b91c0f18ac512debcc111ebe471280e24f579a3b0782",
     url = "https://github.com/buildbuddy-io/rules_xcodeproj/releases/download/0.10.2/release.tar.gz",
 )
 
-# rules_xcodeproj@0.9.0 installs the following repository rules:
-#  1. rules_swift@1.2.0
-#  2. rules_apple@1.1.2
-#  3. apple_support@1.3.0
 load(
     "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:repositories.bzl",
     "xcodeproj_rules_dependencies",

--- a/src/proto/BUILD.bazel
+++ b/src/proto/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("@rules_proto_grpc//swift:defs.bzl", "swift_proto_library")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_proto_library")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -15,11 +15,14 @@ proto_library(
 
 swift_proto_library(
     name = "example_swift_proto",
-    protos = [
+    deps = [
         ":example_proto",
     ],
-    options = {
-        "@rules_proto_grpc//swift:swift_plugin": ["Visibility=Public"],
-    },
-    module_name = "ExampleProto",
+    # protos = [
+    #     ":example_proto",
+    # ],
+    # options = {
+    #     "@rules_proto_grpc//swift:swift_plugin": ["Visibility=Public"],
+    # },
+    # module_name = "ExampleProto",
 )


### PR DESCRIPTION
```
bazel build //src/proto:all
INFO: Analyzed 2 targets (52 packages loaded, 1146 targets configured).
INFO: Found 2 targets...
INFO: From Compiling src/google/protobuf/stubs/strutil.cc [for tool]:
external/com_github_protocolbuffers_protobuf/src/google/protobuf/stubs/strutil.cc:506:11: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
          sprintf(dest + used, (use_hex ? "\\x%02x" : "\\%03o"),
          ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.0.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.0.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
1 warning generated.
ERROR: /Users/p/Code/demos/swift-protobuf-xcode-failure/src/proto/BUILD.bazel:8:14: Generating Swift sources for //src/proto:example_proto failed: (Exit 1): mkdir_and_run.sh failed: error executing command (from target //src/proto:example_proto) bazel-out/darwin_arm64-opt-exec-2B5CBBC6/bin/external/build_bazel_rules_swift/tools/mkdir_and_run/mkdir_and_run.sh bazel-out/darwin_arm64-fastbuild/bin/src/proto/example_proto.protoc_gen_pb_swift ... (remaining 8 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
dyld[47570]: Symbol not found: (_$s10Foundation12CharacterSetV11whitespacesACvgZ)
  Referenced from: '/private/var/tmp/_bazel_p/a2414e84e883c4182b674af589eab4f2/execroot/__main__/bazel-out/darwin_arm64-opt-exec-2B5CBBC6/bin/external/com_github_apple_swift_protobuf/ProtoCompilerPlugin'
  Expected in: '/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation'
--swift_out: protoc-gen-swift: Plugin killed by signal 6.
INFO: Elapsed time: 49.032s, Critical Path: 32.12s
INFO: 239 processes: 21 internal, 214 darwin-sandbox, 4 worker.
FAILED: Build did NOT complete successfully
```